### PR TITLE
Don't issue/overwrite request tracking ID by Go.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- `GoWithID` starts a goroutine with a new request tracking ID.
+
+### Changed
+- `Go` no longer issues new ID automatically.  Use `GoWithID` instead.
 
 ## [1.2.0] - 2016-08-31
 ### Added

--- a/default.go
+++ b/default.go
@@ -62,3 +62,8 @@ func Wait() error {
 func Go(f func(ctx context.Context) error) {
 	defaultEnv.Go(f)
 }
+
+// GoWithID calls Go with a context having a new request tracking ID.
+func GoWithID(f func(ctx context.Context) error) {
+	defaultEnv.GoWithID(f)
+}

--- a/env.go
+++ b/env.go
@@ -129,11 +129,17 @@ func (e *Environment) Go(f func(ctx context.Context) error) {
 	go func() {
 		ctx, cancel := context.WithCancel(e.ctx)
 		defer cancel()
-		ctx = WithRequestID(ctx, e.generator.Generate())
 		err := f(ctx)
 		if err != nil {
 			e.Cancel(err)
 		}
 		e.wg.Done()
 	}()
+}
+
+// GoWithID calls Go with a context having a new request tracking ID.
+func (e *Environment) GoWithID(f func(ctx context.Context) error) {
+	e.Go(func(ctx context.Context) error {
+		return f(WithRequestID(ctx, e.generator.Generate()))
+	})
 }

--- a/env_test.go
+++ b/env_test.go
@@ -97,7 +97,7 @@ func TestEnvironmentID(t *testing.T) {
 	env := NewEnvironment(context.Background())
 
 	idch := make(chan interface{}, 1)
-	env.Go(func(ctx context.Context) error {
+	env.GoWithID(func(ctx context.Context) error {
 		idch <- ctx.Value(RequestIDContextKey)
 		return nil
 	})

--- a/server_test.go
+++ b/server_test.go
@@ -31,6 +31,11 @@ func TestServer(t *testing.T) {
 
 	l := listen(15555, t)
 	handler := func(ctx context.Context, conn net.Conn) {
+		if ctx.Value(RequestIDContextKey) == nil {
+			// handler must receive a new request ID.
+			return
+		}
+
 		conn.Write([]byte{'h', 'e', 'l', 'l', 'o'})
 		<-ctx.Done()
 


### PR DESCRIPTION
Environment.Go used to issue a new request ID implicitly.
This may result in unwilling overwrite of the existing ID.

This commit changes Go not to issue ID, and adds GoWithID method
to issue a new request ID explicitly.